### PR TITLE
Use HashRouter

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -102,7 +102,7 @@ function App() {
           </button>
           <div className="text-silver text-2xl text-center">
             Already have an account?{" "}
-            <a className="underline text-blue-500" href="/login">
+            <a className="underline text-blue-500" href="#/login">
               Login
             </a>
           </div>

--- a/src/index.js
+++ b/src/index.js
@@ -3,15 +3,15 @@ import ReactDOM from "react-dom/client";
 import "./index.css";
 import App from "./App";
 import reportWebVitals from "./reportWebVitals";
-import { createBrowserRouter, RouterProvider } from "react-router-dom";
+import { createHashRouter, RouterProvider } from "react-router-dom";
 import Home from "./pages/home";
 import Login from "./pages/login";
 import Question from "./pages/question";
 import Friend from "./pages/friend";
 
-const router = createBrowserRouter([
+const router = createHashRouter([
   {
-    path: "space",
+    path: "/",
     element: <App />,
   },
   {


### PR DESCRIPTION
Why:

* Right now on our github page we can't refresh or go to another links without a 404 error.

This change addresses the need by:

* Using HashRouter from `react-router-dom` instead of BrowserRouter.