### PR TITLE
Change friend getter to receive error when user not paired.

### DIFF
--- a/src/pages/friend.js
+++ b/src/pages/friend.js
@@ -29,14 +29,15 @@ function Friend() {
   const [notPaired, setNotPaired] = useState(false);
 
   useEffect(() => {
-    getFriend().then((response) => setFriendData(response));
+    getFriend()
+      .then((response) => {
+        if (response.error) {
+          setNotPaired(true); 
+        } else {
+          setFriendData(response);
+        }
+      });
   }, [notPaired]);
-
-  useEffect(() => {
-    if (friendData.id === parseInt(current_user_id)) {
-      setNotPaired(true);
-    }
-  }, [notPaired, friendData]);
 
   return (
     <div>


### PR DESCRIPTION
Why:

* Now the friends controller returns an error when the user does not have a friend so we need to change the way the frontend receives and sets the friend data.

This change addresses the need by:

* Make `getFriend` receive an error and set `not_paired` flag to true if there's no friend. 
