### PR TITLE
Run Prettier

### DIFF
--- a/src/pages/friend.js
+++ b/src/pages/friend.js
@@ -29,14 +29,13 @@ function Friend() {
   const [notPaired, setNotPaired] = useState(false);
 
   useEffect(() => {
-    getFriend()
-      .then((response) => {
-        if (response.error) {
-          setNotPaired(true); 
-        } else {
-          setFriendData(response);
-        }
-      });
+    getFriend().then((response) => {
+      if (response.error) {
+        setNotPaired(true);
+      } else {
+        setFriendData(response);
+      }
+    });
   }, [notPaired]);
 
   return (


### PR DESCRIPTION
Why:

* Deploy giving an error because of lint.

This change addresses the need by:

* Using the command to run prettier and fix the format.
