### PR TITLE
Use names instead of emails

### DIFF
--- a/src/pages/previous_questions.js
+++ b/src/pages/previous_questions.js
@@ -79,7 +79,7 @@ function PreviousQuestions() {
                           src={answer.user.profile_pic}
                           alt="User profile pic"
                         />
-                        <div className="text-xl ml-14">{answer.user.email}</div>
+                        <div className="text-xl ml-14">{answer.user.name}</div>
                         <div className="text-xs ml-14 font-normal">
                           {new Date(answer.created_at)
                             .toLocaleString(undefined, options)

--- a/src/pages/question.js
+++ b/src/pages/question.js
@@ -45,11 +45,11 @@ function Question() {
     ).then((values) => {
       const data = values.map((value) => {
         return {
-          email: value.user.email,
           body: value.body,
           time: value.time,
           user: value.user.id,
           image: value.user.profile_pic,
+          name: value.user.name,
         };
       });
       setAnswers(data);
@@ -193,7 +193,7 @@ function Question() {
                       src={item.image}
                       alt="User profile pic"
                     />
-                    <div className="text-xl ml-14">{item.email}</div>
+                    <div className="text-xl ml-14">{item.name}</div>
                     <div className="text-xs ml-14 font-normal">
                       {item.time
                         .toLocaleString(undefined, options)


### PR DESCRIPTION
Why:

* Displayed emails instead of names

This change addresses the need by:

* Fetching names of the users

